### PR TITLE
Booleans values true and false

### DIFF
--- a/.github/linters/.yaml-lint.yml
+++ b/.github/linters/.yaml-lint.yml
@@ -12,5 +12,4 @@ rules:
     indent-sequences: consistent
   line-length: disable
   truthy:
-    level: warning
-    allowed-values: ["true", "false", "on"]
+    allowed-values: ["true", "false"]


### PR DESCRIPTION
The reason why we should not use values other than true/false in booleans. Read here: https://hitchdev.com/strictyaml/why/implicit-typing-removed/