### PR TITLE
Disable yamllint in ansible-lint

### DIFF
--- a/.github/linters/.ansible-lint.yml
+++ b/.github/linters/.ansible-lint.yml
@@ -8,3 +8,5 @@ exclude_paths:
   - docs/
 use_default_rules: true
 verbosity: 1
+skip_list:
+  - yaml


### PR DESCRIPTION
We run the yamllint separately with super-lint. See Docs of Ansible-lint: https://ansible-lint.readthedocs.io/en/latest/default_rules.html#yaml