### PR TITLE
Validate Kubernetes Custom Resources

### DIFF
--- a/.github/workflows/super-linter-non-slim.yml
+++ b/.github/workflows/super-linter-non-slim.yml
@@ -46,6 +46,7 @@ jobs:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ github.token }}
+          KUBERNETES_KUBEVAL_OPTIONS: --ignore-missing-schemas
           LINTER_RULES_PATH: "${{ inputs.CODEQUALITY_PATH }}/.github/linters"
           ANSIBLE_DIRECTORY: ${{ inputs.ANSIBLE_DIRECTORY }}
           VALIDATE_JSCPD: false

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -46,6 +46,7 @@ jobs:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ github.token }}
+          KUBERNETES_KUBEVAL_OPTIONS: --ignore-missing-schemas
           LINTER_RULES_PATH: "${{ inputs.CODEQUALITY_PATH }}/.github/linters"
           ANSIBLE_DIRECTORY: ${{ inputs.ANSIBLE_DIRECTORY }}
           VALIDATE_JSCPD: false


### PR DESCRIPTION
Currently the super linter cannot validate Kubernetes Custom Resources since it cannot know its schema, see [this error](https://github.com/riege/terraform-app-flux/runs/4708967943?check_suite_focus=true).

Fortunately one can [pass options to `kubeval` to ignore missing schemas](https://github.com/github/super-linter/pull/1609).