### PR TITLE
Use github.token instead of secrets.GITHUB_TOKEN

### DIFF
--- a/.github/workflows/super-linter-non-slim.yml
+++ b/.github/workflows/super-linter-non-slim.yml
@@ -45,7 +45,7 @@ jobs:
         env:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: main
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           LINTER_RULES_PATH: "${{ inputs.CODEQUALITY_PATH }}/.github/linters"
           ANSIBLE_DIRECTORY: ${{ inputs.ANSIBLE_DIRECTORY }}
           VALIDATE_JSCPD: false

--- a/.github/workflows/super-linter-non-slim.yml
+++ b/.github/workflows/super-linter-non-slim.yml
@@ -22,6 +22,10 @@ on:
           "Flag to set the root directory for Ansible file location(s),
           relative to DEFAULT_WORKSPACE. Set to . to use the top-level of
           the DEFAULT_WORKSPACE."
+    secrets:
+      GITHUB_TOKEN:
+        required: false
+        description: "GitHub token to mark status of each individual linter run in checks."
 
 jobs:
   build:

--- a/.github/workflows/super-linter-non-slim.yml
+++ b/.github/workflows/super-linter-non-slim.yml
@@ -22,10 +22,6 @@ on:
           "Flag to set the root directory for Ansible file location(s),
           relative to DEFAULT_WORKSPACE. Set to . to use the top-level of
           the DEFAULT_WORKSPACE."
-    secrets:
-      GITHUB_TOKEN:
-        required: false
-        description: "GitHub token to mark status of each individual linter run in checks."
 
 jobs:
   build:

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -22,6 +22,10 @@ on:
           "Flag to set the root directory for Ansible file location(s),
           relative to DEFAULT_WORKSPACE. Set to . to use the top-level of
           the DEFAULT_WORKSPACE."
+    secrets:
+      GITHUB_TOKEN:
+        required: false
+        description: "GitHub token to mark status of each individual linter run in checks."
 
 jobs:
   build:

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -22,10 +22,6 @@ on:
           "Flag to set the root directory for Ansible file location(s),
           relative to DEFAULT_WORKSPACE. Set to . to use the top-level of
           the DEFAULT_WORKSPACE."
-    secrets:
-      GITHUB_TOKEN:
-        required: false
-        description: "GitHub token to mark status of each individual linter run in checks."
 
 jobs:
   build:
@@ -49,7 +45,7 @@ jobs:
         env:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: main
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           LINTER_RULES_PATH: "${{ inputs.CODEQUALITY_PATH }}/.github/linters"
           ANSIBLE_DIRECTORY: ${{ inputs.ANSIBLE_DIRECTORY }}
           VALIDATE_JSCPD: false


### PR DESCRIPTION
Edit: Ok, now I am confused. The doc reads:

> The called workflow is automatically granted access to `github.token` and `secrets.GITHUB_TOKEN`.

So maybe this PR _should_ not be required at all? On the other hand, why does the check in #13 fail?

Original comment:

Reusable workflows don't have access to caller secrets unless you pass them as `secret`.

I would like to make the `GITHUB_TOKEN` even `required` but that would break existing workflows...

Maybe introduce versioning for breaking changes? ;-)