### PR TITLE
Allow unordered properties

### DIFF
--- a/java/checkstyle/checkstyle.xml
+++ b/java/checkstyle/checkstyle.xml
@@ -214,7 +214,6 @@
         <property name="lineSeparator" value="lf"/>
         <property name="fileExtensions" value="java, groovy, properties"/>
     </module>
-    <module name="OrderedProperties"/>
     <module name="UniqueProperties" />
     <module name="SuppressWithPlainTextCommentFilter">
         <property name="offCommentFormat" value="CHECKSTYLE.OFF\: ([\w\|]+)"/>


### PR DESCRIPTION
Sometimes it makes more sense to use a different ordering in property files. Let's not be too strict.