### PR TITLE
Revert "Allow unordered properties"

### DIFF
--- a/java/checkstyle/checkstyle.xml
+++ b/java/checkstyle/checkstyle.xml
@@ -214,6 +214,7 @@
         <property name="lineSeparator" value="lf"/>
         <property name="fileExtensions" value="java, groovy, properties"/>
     </module>
+    <module name="OrderedProperties"/>
     <module name="UniqueProperties" />
     <module name="SuppressWithPlainTextCommentFilter">
         <property name="offCommentFormat" value="CHECKSTYLE.OFF\: ([\w\|]+)"/>


### PR DESCRIPTION
It is always easier to find a property when they are sorted instead of some colleague arbitrarily placing it somewhere in a properties file.