### PR TITLE
Provide tflint-only reusable workflow

### DIFF
--- a/.github/workflows/tflint.yml
+++ b/.github/workflows/tflint.yml
@@ -38,12 +38,12 @@ jobs:
         name: Setup TFLint
 
       - name: Init TFLint
-        run: tflint --init --config=$TFLINT_CONFIG_FILE
+        run: tflint --init --config="$TFLINT_CONFIG_FILE"
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Run TFLint
-        run: tflint --format=checkstyle --recursive --config=$TFLINT_CONFIG_FILE > tflint-report.xml
+        run: tflint --format=checkstyle --recursive --config="$TFLINT_CONFIG_FILE" > tflint-report.xml
 
       - name: Report Result
         uses: jwgmeligmeyling/checkstyle-github-action@master

--- a/.github/workflows/tflint.yml
+++ b/.github/workflows/tflint.yml
@@ -1,0 +1,45 @@
+name: Reusable tflint workflow
+
+on:
+  workflow_call:
+    inputs:
+      CODEQUALITY_REF:
+        required: false
+        type: string
+        default: "main"
+        description: "Reference of the code-quality repo to use."
+
+jobs:
+  tflint:
+    name: Run tflint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - uses: terraform-linters/tflint-load-config-action@v0
+        with:
+          source-repo: riege/code-quality
+          source-path: terraform/.tflint.hcl
+          source-ref: ${{ inputs.CODEQUALITY_REF }}
+
+      - name: Determine tflint config file location
+        run: |
+          echo "TFLINT_CONFIG_FILE=$HOME/.tflint.hcl" >> "$GITHUB_ENV"
+
+      - uses: actions/cache@v3
+        name: Cache plugin dir
+        with:
+          path: ~/.tflint.d/plugins
+          key: tflint-${{ hashFiles(env.TFLINT_CONFIG_FILE) }}
+
+      - uses: terraform-linters/setup-tflint@v3
+        name: Setup TFLint
+
+      - name: Init TFLint
+        run: tflint --init
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Run TFLint
+        run: tflint --format=compact --recursive

--- a/.github/workflows/tflint.yml
+++ b/.github/workflows/tflint.yml
@@ -22,10 +22,11 @@ jobs:
           source-repo: riege/code-quality
           source-path: terraform/.tflint.hcl
           source-ref: ${{ inputs.CODEQUALITY_REF }}
+          destination-path: ${{ github.workspace }}/.tflint.hcl
 
       - name: Determine tflint config file location
         run: |
-          echo "TFLINT_CONFIG_FILE=$HOME/.tflint.hcl" >> "$GITHUB_ENV"
+          echo "TFLINT_CONFIG_FILE=${{ github.workspace }}/.tflint.hcl" >> "$GITHUB_ENV"
 
       - uses: actions/cache@v3
         name: Cache plugin dir
@@ -37,9 +38,9 @@ jobs:
         name: Setup TFLint
 
       - name: Init TFLint
-        run: tflint --init
+        run: tflint --init --config=$TFLINT_CONFIG_FILE
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Run TFLint
-        run: tflint --format=compact --recursive
+        run: tflint --format=compact --recursive --config=$TFLINT_CONFIG_FILE

--- a/.github/workflows/tflint.yml
+++ b/.github/workflows/tflint.yml
@@ -43,4 +43,12 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Run TFLint
-        run: tflint --format=compact --recursive --config=$TFLINT_CONFIG_FILE
+        run: tflint --format=checkstyle --recursive --config=$TFLINT_CONFIG_FILE > tflint-report.xml
+
+      - name: Report Result
+        uses: jwgmeligmeyling/checkstyle-github-action@master
+        if: success() || failure()
+        with:
+          title: TFLINT Report
+          name: tflint Report
+          path: tflint-report.xml

--- a/terraform/.tflint.hcl
+++ b/terraform/.tflint.hcl
@@ -1,33 +1,34 @@
-// https://github.com/terraform-linters/tflint/blob/master/docs/user-guide/config.md
+# https://github.com/terraform-linters/tflint/blob/master/docs/user-guide/config.md
+# https://github.com/github/super-linter/blob/main/TEMPLATES/.tflint.hcl
 config {
   module = false
   force  = false
 }
 
-// using "recommended" set of rules is sufficient
 plugin "terraform" {
   enabled = true
-  preset  = "recommended"
+  preset  = "all"
 }
 
-// we do want to enforce naming conventions
-rule "terraform_naming_convention" {
-  enabled = true
-}
-
-// nobody likes unused providers
-rule "terraform_unused_required_providers" {
-  enabled = true
-}
-
-// we do not want to enforce specifying a required Terraform version as we usually run the configs with the latest version
-rule "terraform_required_version" {
-  enabled = false
-}
-
-// add special rules for MS Azure Resource Manager
+# add special rules for MS Azure Resource Manager
 plugin "azurerm" {
   enabled = true
   version = "0.23.0"
   source  = "github.com/terraform-linters/tflint-ruleset-azurerm"
+}
+
+# we do not want to enforce specifying a required Terraform version as we usually run the configs with the latest version
+rule "terraform_required_version" {
+  enabled = false
+}
+
+# some modules simply don't have outputs or variables
+rule "terraform_standard_module_structure" {
+  enabled = false
+}
+
+# child modules usually don't specify their provider versions
+# if it's also missing in the root module then Terraform will complain
+rule "terraform_required_providers" {
+  enabled = false
 }


### PR DESCRIPTION
A minimal reusable workflow to properly and quickly lint Terraform files only.

- lightning fast (< 20s)
- based on "all" tflint terraform preset
- some rules have been deliberately disabled (see comments of `.tflint.hcl` file)
- allows us to use our well-known Terraform structure regarding `required_providers`: all providers with full version in root module, just the name of the provider in child modules - this is compatible with Renovate allowing for proper dependency updates
- performs recursive linting using the same config file for all modules
- super simple usage - no inputs needed
- creates code annotations for PRs using checkstyle reports

Example: https://github.com/wiebeck/test-terraform-renovate/pull/5 (note that the workflow specifies a `CODEQUALITY_REF` input variable. This will not be necessary after this PR got merged.