### PR TITLE
JavaEE is dead, long live Jakarta EE - even for static imports

### DIFF
--- a/java/checkstyle/checkstyle.xml
+++ b/java/checkstyle/checkstyle.xml
@@ -99,7 +99,7 @@
             <property name="sortStaticImportsAlphabetically" value="true"/>
             <property name="separatedStaticGroups" value="true"/>
             <property name="staticGroups"
-                      value="io, java, javax, junit, org, com, com.jgoodies, com.riege"/>
+                      value="io, java, javax, jakarta, junit, org, com, com.jgoodies, com.riege"/>
         </module>
         <module name="RedundantImport"/>
         <module name="UnusedImports">


### PR DESCRIPTION
Keep ImportOrder in sync between groups ('jakarta' added in c6b323) and staticGroups