### PR TITLE
Add fake OpsGenie API key

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -10,6 +10,10 @@ on:
         type: boolean
         description: "Set to 'true' if Terraform validation shall be skipped. Might be necessary in some rare cases."
 
+env:
+  # OpsGenie Terraform provider needs this to be non-empty, even if we only validate the code.
+  OPSGENIE_API_KEY: "123" 
+
 jobs:
   terraform:
     name: Check Terraform

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   # OpsGenie Terraform provider needs this to be non-empty, even if we only validate the code.
-  OPSGENIE_API_KEY: "123" 
+  OPSGENIE_API_KEY: "123"
 
 jobs:
   terraform:


### PR DESCRIPTION
The OpsGenie Terraform provider needs a non-empty API key variable to run, even if we only validate the code.