### PR TITLE
Shared settings for XML via Spotless

### DIFF
--- a/xml/xml.prefs
+++ b/xml/xml.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+lineWidth=110


### PR DESCRIPTION
Default value of 72 leads to many ugly line breaks which make the XMLs less readable.