### PR TITLE
Add module 'SuppressionFilter' to checkstyle config

### DIFF
--- a/java/checkstyle/checkstyle.xml
+++ b/java/checkstyle/checkstyle.xml
@@ -220,4 +220,7 @@
         <property name="onCommentFormat" value="CHECKSTYLE.ON\: ([\w\|]+)"/>
         <property name="checkFormat" value="$1"/>
     </module>
+    <module name="SuppressionFilter">
+        <property name="file" value="${config_loc}/suppressions.xml"/>
+    </module>
 </module>


### PR DESCRIPTION
The [`SuppressionFilter`](https://checkstyle.sourceforge.io/apidocs/com/puppycrawl/tools/checkstyle/filters/SuppressionFilter.html) module allows to specify files in a `suppressions.xml` for which certain or all checks will be suppressed. This comes in handy for generated files, for instance, which normally should not be checked but could produce checkstyle errors if they are checked.

The placeholder `${config_loc}` is understood by the [Gradle checkstyle plugin](https://docs.gradle.org/current/userguide/checkstyle_plugin.html). It replaces the placeholder with the defined [configuration directory](https://docs.gradle.org/current/dsl/org.gradle.api.plugins.quality.CheckstyleExtension.html#org.gradle.api.plugins.quality.CheckstyleExtension:configDirectory).