### PR TITLE
Remove suppression filter again

### DIFF
--- a/java/checkstyle/checkstyle.xml
+++ b/java/checkstyle/checkstyle.xml
@@ -220,7 +220,4 @@
         <property name="onCommentFormat" value="CHECKSTYLE.ON\: ([\w\|]+)"/>
         <property name="checkFormat" value="$1"/>
     </module>
-    <module name="SuppressionFilter">
-        <property name="file" value="${config_loc}/suppressions.xml"/>
-    </module>
 </module>


### PR DESCRIPTION
It turns out that the Gradle checkstyle task throws an error if the filter `suppressions.xml` is not available. So it's not a good idea to add it to the global config and it's better to revert this step.