### PR TITLE
Add Error Prone config file

### DIFF
--- a/java/errorprone/errorprone.json
+++ b/java/errorprone/errorprone.json
@@ -1,0 +1,9 @@
+{
+  "checks": {
+    "NullAway": "ERROR"
+  },
+  "options": {
+    "NullAway:AnnotatedPackages": "com.riege",
+    "NullAway:ExcludedFieldAnnotations": "[a-zA-Z0-9.]*.(ConfigProperty|RestClient)"
+  }
+}


### PR DESCRIPTION
This PR is related to https://github.com/riege/quarkus-app-template/pull/198.

It adds a basic configuration file for [Error Prone](https://errorprone.info/), a Java compiler plugin that performs static code analysis. Error Prone is meant as a replacement for SpotBugs in new Java projects, especially Quarkus services.