### PR TITLE
Add default pattern for imports

### DIFF
--- a/java/checkstyle/checkstyle.xml
+++ b/java/checkstyle/checkstyle.xml
@@ -29,7 +29,7 @@
     </module>
     <module name="LineLength">
         <property name="ignorePattern"
-                  value="^ *(((public|private|protected)? (static final|abstract))|@ImportFieldCompletion|@Update|@Field|@AttributeOverride|public (abstract |final )?(class|interface|enum)|assertEquals|[\p{Upper}\p{Digit}_]* *(\(|,))"/>
+                  value="^(package|import) .*|^ *(((public|private|protected)? (static final|abstract))|@ImportFieldCompletion|@Update|@Field|@AttributeOverride|public (abstract |final )?(class|interface|enum)|assertEquals|[\p{Upper}\p{Digit}_]* *(\(|,))"/>
         <property name="max" value="100"/>
         <property name="fileExtensions" value="java"/>
     </module>


### PR DESCRIPTION
This commit adds the default pattern of the LineLength (https://checkstyle.sourceforge.io/checks/sizes/linelength.html) check to the ignored patterns. The pattern will exempt import and package declarations from the line length check.