### PR TITLE
Disable Checkov check CKV2_GHA_1

### DIFF
--- a/.github/workflows/super-linter-non-slim.yml
+++ b/.github/workflows/super-linter-non-slim.yml
@@ -53,6 +53,7 @@ jobs:
         env:
           ANSIBLE_CONFIG_FILE: ansible/.ansible-lint.yml
           ANSIBLE_DIRECTORY: ${{ inputs.ANSIBLE_DIRECTORY }}
+          CHECKOV_FILE_NAME: checkov/.checkov.yaml
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ github.token }}
           JAVA_FILE_NAME: java/checkstyle/checkstyle.xml

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -65,6 +65,7 @@ jobs:
         env:
           ANSIBLE_CONFIG_FILE: ansible/.ansible-lint.yml
           ANSIBLE_DIRECTORY: ${{ inputs.ANSIBLE_DIRECTORY }}
+          CHECKOV_FILE_NAME: checkov/.checkov.yaml
           DEFAULT_BRANCH: main
           FILTER_REGEX_EXCLUDE: "${{ inputs.FILTER_REGEX_EXCLUDE }}"
           GITHUB_TOKEN: ${{ github.token }}

--- a/checkov/.checkov.yaml
+++ b/checkov/.checkov.yaml
@@ -1,0 +1,7 @@
+---
+# Don't report passed checks in output
+quiet: true
+
+# Skip specific checks by their Checkov ID
+skip-check:
+  - CKV2_GHA_1 # We want to allow top-level GH Actions permissions to be write-all


### PR DESCRIPTION
We want to allow top-level GH Actions permissions to be write-all