### PR TITLE
feat: add include-mode lint inputs for super-linter

### DIFF
--- a/.github/workflows/super-linter-non-slim.yml
+++ b/.github/workflows/super-linter-non-slim.yml
@@ -57,13 +57,13 @@ on:
       VALIDATE_MARKDOWN:
         required: false
         type: boolean
-        default: true
+        default: false
         description: >
           "Enable Markdown validation in include mode."
       VALIDATE_YAML:
         required: false
         type: boolean
-        default: true
+        default: false
         description: >
           "Enable YAML validation in include mode."
       VALIDATE_MARKDOWN_PRETTIER:
@@ -97,7 +97,7 @@ jobs:
           ref: ${{ inputs.CODEQUALITY_REF }}
 
       - name: Lint Code Base (include mode)
-        if: ${{ inputs.VALIDATE_KUBERNETES_KUBEVAL || inputs.VALIDATE_GITHUB_ACTIONS || inputs.VALIDATE_CHECKOV || inputs.VALIDATE_GITLEAKS || inputs.VALIDATE_MARKDOWN_PRETTIER || inputs.VALIDATE_YAML_PRETTIER }}
+        if: ${{ inputs.VALIDATE_KUBERNETES_KUBEVAL || inputs.VALIDATE_GITHUB_ACTIONS || inputs.VALIDATE_CHECKOV || inputs.VALIDATE_GITLEAKS || inputs.VALIDATE_MARKDOWN || inputs.VALIDATE_YAML || inputs.VALIDATE_MARKDOWN_PRETTIER || inputs.VALIDATE_YAML_PRETTIER }}
         uses: github/super-linter@v7
         env:
           ANSIBLE_CONFIG_FILE: ansible/.ansible-lint.yml
@@ -123,7 +123,7 @@ jobs:
           SQLFLUFF_CONFIG_FILE: sqlfluff/.sqlfluff-lint
 
       - name: Lint Code Base (exclude mode)
-        if: ${{ !(inputs.VALIDATE_KUBERNETES_KUBEVAL || inputs.VALIDATE_GITHUB_ACTIONS || inputs.VALIDATE_CHECKOV || inputs.VALIDATE_GITLEAKS || inputs.VALIDATE_MARKDOWN_PRETTIER || inputs.VALIDATE_YAML_PRETTIER) }}
+        if: ${{ !(inputs.VALIDATE_KUBERNETES_KUBEVAL || inputs.VALIDATE_GITHUB_ACTIONS || inputs.VALIDATE_CHECKOV || inputs.VALIDATE_GITLEAKS || inputs.VALIDATE_MARKDOWN || inputs.VALIDATE_YAML || inputs.VALIDATE_MARKDOWN_PRETTIER || inputs.VALIDATE_YAML_PRETTIER) }}
         uses: github/super-linter@v7
         env:
           ANSIBLE_CONFIG_FILE: ansible/.ansible-lint.yml

--- a/.github/workflows/super-linter-non-slim.yml
+++ b/.github/workflows/super-linter-non-slim.yml
@@ -54,6 +54,18 @@ on:
         default: false
         description: >
           "Enable Gitleaks validation."
+      VALIDATE_MARKDOWN_PRETTIER:
+        required: false
+        type: boolean
+        default: false
+        description: >
+          "Enable Markdown Prettier validation."
+      VALIDATE_YAML_PRETTIER:
+        required: false
+        type: boolean
+        default: false
+        description: >
+          "Enable YAML Prettier validation."
 
 jobs:
   build:
@@ -73,7 +85,7 @@ jobs:
           ref: ${{ inputs.CODEQUALITY_REF }}
 
       - name: Lint Code Base (include mode)
-        if: ${{ inputs.VALIDATE_KUBERNETES_KUBEVAL || inputs.VALIDATE_GITHUB_ACTIONS || inputs.VALIDATE_CHECKOV || inputs.VALIDATE_GITLEAKS }}
+        if: ${{ inputs.VALIDATE_KUBERNETES_KUBEVAL || inputs.VALIDATE_GITHUB_ACTIONS || inputs.VALIDATE_CHECKOV || inputs.VALIDATE_GITLEAKS || inputs.VALIDATE_MARKDOWN_PRETTIER || inputs.VALIDATE_YAML_PRETTIER }}
         uses: github/super-linter@v7
         env:
           ANSIBLE_CONFIG_FILE: ansible/.ansible-lint.yml
@@ -92,12 +104,14 @@ jobs:
           VALIDATE_GITHUB_ACTIONS: ${{ inputs.VALIDATE_GITHUB_ACTIONS && 'true' || '' }}
           VALIDATE_CHECKOV: ${{ inputs.VALIDATE_CHECKOV && 'true' || '' }}
           VALIDATE_GITLEAKS: ${{ inputs.VALIDATE_GITLEAKS && 'true' || '' }}
+          VALIDATE_MARKDOWN_PRETTIER: ${{ inputs.VALIDATE_MARKDOWN_PRETTIER && 'true' || '' }}
+          VALIDATE_YAML_PRETTIER: ${{ inputs.VALIDATE_YAML_PRETTIER && 'true' || '' }}
           YAML_CONFIG_FILE: yaml/.yaml-lint.yml
           TERRAFORM_TFLINT_CONFIG_FILE: terraform/.tflint.hcl
           SQLFLUFF_CONFIG_FILE: sqlfluff/.sqlfluff-lint
 
       - name: Lint Code Base (exclude mode)
-        if: ${{ !(inputs.VALIDATE_KUBERNETES_KUBEVAL || inputs.VALIDATE_GITHUB_ACTIONS || inputs.VALIDATE_CHECKOV || inputs.VALIDATE_GITLEAKS) }}
+        if: ${{ !(inputs.VALIDATE_KUBERNETES_KUBEVAL || inputs.VALIDATE_GITHUB_ACTIONS || inputs.VALIDATE_CHECKOV || inputs.VALIDATE_GITLEAKS || inputs.VALIDATE_MARKDOWN_PRETTIER || inputs.VALIDATE_YAML_PRETTIER) }}
         uses: github/super-linter@v7
         env:
           ANSIBLE_CONFIG_FILE: ansible/.ansible-lint.yml

--- a/.github/workflows/super-linter-non-slim.yml
+++ b/.github/workflows/super-linter-non-slim.yml
@@ -30,6 +30,30 @@ on:
           "Will parse the entire repository and find all files to validate
           across all types. NOTE: When set to false, only new or edited files
           will be parsed for validation."
+      VALIDATE_KUBERNETES_KUBEVAL:
+        required: false
+        type: boolean
+        default: false
+        description: >
+          "Enable kubeval validation for Kubernetes manifests."
+      VALIDATE_GITHUB_ACTIONS:
+        required: false
+        type: boolean
+        default: false
+        description: >
+          "Enable GitHub Actions validation."
+      VALIDATE_CHECKOV:
+        required: false
+        type: boolean
+        default: false
+        description: >
+          "Enable Checkov validation."
+      VALIDATE_GITLEAKS:
+        required: false
+        type: boolean
+        default: false
+        description: >
+          "Enable Gitleaks validation."
 
 jobs:
   build:
@@ -48,7 +72,32 @@ jobs:
           path: ${{ inputs.CODEQUALITY_PATH }}
           ref: ${{ inputs.CODEQUALITY_REF }}
 
-      - name: Lint Code Base
+      - name: Lint Code Base (include mode)
+        if: ${{ inputs.VALIDATE_KUBERNETES_KUBEVAL || inputs.VALIDATE_GITHUB_ACTIONS || inputs.VALIDATE_CHECKOV || inputs.VALIDATE_GITLEAKS }}
+        uses: github/super-linter@v7
+        env:
+          ANSIBLE_CONFIG_FILE: ansible/.ansible-lint.yml
+          ANSIBLE_DIRECTORY: ${{ inputs.ANSIBLE_DIRECTORY }}
+          CHECKOV_FILE_NAME: checkov/.checkov.yaml
+          DEFAULT_BRANCH: main
+          GITHUB_TOKEN: ${{ github.token }}
+          JAVA_FILE_NAME: java/checkstyle/checkstyle.xml
+          KUBERNETES_KUBEVAL_OPTIONS: --ignore-missing-schemas
+          LINTER_RULES_PATH: "${{ inputs.CODEQUALITY_PATH }}/"
+          MARKDOWN_CONFIG_FILE: markdown/.markdown-lint.yml
+          VALIDATE_ALL_CODEBASE: "${{ inputs.VALIDATE_ALL_CODEBASE }}"
+          VALIDATE_MARKDOWN: "true"
+          VALIDATE_YAML: "true"
+          VALIDATE_KUBERNETES_KUBEVAL: ${{ inputs.VALIDATE_KUBERNETES_KUBEVAL && 'true' || '' }}
+          VALIDATE_GITHUB_ACTIONS: ${{ inputs.VALIDATE_GITHUB_ACTIONS && 'true' || '' }}
+          VALIDATE_CHECKOV: ${{ inputs.VALIDATE_CHECKOV && 'true' || '' }}
+          VALIDATE_GITLEAKS: ${{ inputs.VALIDATE_GITLEAKS && 'true' || '' }}
+          YAML_CONFIG_FILE: yaml/.yaml-lint.yml
+          TERRAFORM_TFLINT_CONFIG_FILE: terraform/.tflint.hcl
+          SQLFLUFF_CONFIG_FILE: sqlfluff/.sqlfluff-lint
+
+      - name: Lint Code Base (exclude mode)
+        if: ${{ !(inputs.VALIDATE_KUBERNETES_KUBEVAL || inputs.VALIDATE_GITHUB_ACTIONS || inputs.VALIDATE_CHECKOV || inputs.VALIDATE_GITLEAKS) }}
         uses: github/super-linter@v7
         env:
           ANSIBLE_CONFIG_FILE: ansible/.ansible-lint.yml
@@ -63,7 +112,6 @@ jobs:
           VALIDATE_ALL_CODEBASE: "${{ inputs.VALIDATE_ALL_CODEBASE }}"
           VALIDATE_JSCPD: false
           VALIDATE_NATURAL_LANGUAGE: false
-          VALIDATE_KUBERNETES_KUBEVAL: false
           YAML_CONFIG_FILE: yaml/.yaml-lint.yml
           TERRAFORM_TFLINT_CONFIG_FILE: terraform/.tflint.hcl
           SQLFLUFF_CONFIG_FILE: sqlfluff/.sqlfluff-lint

--- a/.github/workflows/super-linter-non-slim.yml
+++ b/.github/workflows/super-linter-non-slim.yml
@@ -112,6 +112,7 @@ jobs:
           VALIDATE_ALL_CODEBASE: "${{ inputs.VALIDATE_ALL_CODEBASE }}"
           VALIDATE_JSCPD: false
           VALIDATE_NATURAL_LANGUAGE: false
+          VALIDATE_KUBERNETES_KUBEVAL: false
           YAML_CONFIG_FILE: yaml/.yaml-lint.yml
           TERRAFORM_TFLINT_CONFIG_FILE: terraform/.tflint.hcl
           SQLFLUFF_CONFIG_FILE: sqlfluff/.sqlfluff-lint

--- a/.github/workflows/super-linter-non-slim.yml
+++ b/.github/workflows/super-linter-non-slim.yml
@@ -54,6 +54,18 @@ on:
         default: false
         description: >
           "Enable Gitleaks validation."
+      VALIDATE_MARKDOWN:
+        required: false
+        type: boolean
+        default: true
+        description: >
+          "Enable Markdown validation in include mode."
+      VALIDATE_YAML:
+        required: false
+        type: boolean
+        default: true
+        description: >
+          "Enable YAML validation in include mode."
       VALIDATE_MARKDOWN_PRETTIER:
         required: false
         type: boolean
@@ -98,8 +110,8 @@ jobs:
           LINTER_RULES_PATH: "${{ inputs.CODEQUALITY_PATH }}/"
           MARKDOWN_CONFIG_FILE: markdown/.markdown-lint.yml
           VALIDATE_ALL_CODEBASE: "${{ inputs.VALIDATE_ALL_CODEBASE }}"
-          VALIDATE_MARKDOWN: "true"
-          VALIDATE_YAML: "true"
+          VALIDATE_MARKDOWN: ${{ inputs.VALIDATE_MARKDOWN && 'true' || '' }}
+          VALIDATE_YAML: ${{ inputs.VALIDATE_YAML && 'true' || '' }}
           VALIDATE_KUBERNETES_KUBEVAL: ${{ inputs.VALIDATE_KUBERNETES_KUBEVAL && 'true' || '' }}
           VALIDATE_GITHUB_ACTIONS: ${{ inputs.VALIDATE_GITHUB_ACTIONS && 'true' || '' }}
           VALIDATE_CHECKOV: ${{ inputs.VALIDATE_CHECKOV && 'true' || '' }}

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -98,7 +98,7 @@ jobs:
 
       - name: Lint Code Base (include mode)
         if: ${{ inputs.VALIDATE_KUBERNETES_KUBEVAL || inputs.VALIDATE_GITHUB_ACTIONS || inputs.VALIDATE_CHECKOV || inputs.VALIDATE_GITLEAKS || inputs.VALIDATE_MARKDOWN_PRETTIER || inputs.VALIDATE_YAML_PRETTIER }}
-        uses: github/super-linter@v7
+        uses: github/super-linter/slim@v7
         env:
           ANSIBLE_CONFIG_FILE: ansible/.ansible-lint.yml
           ANSIBLE_DIRECTORY: ${{ inputs.ANSIBLE_DIRECTORY }}

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -126,6 +126,7 @@ jobs:
           VALIDATE_ALL_CODEBASE: "${{ inputs.VALIDATE_ALL_CODEBASE }}"
           VALIDATE_JSCPD: false
           VALIDATE_NATURAL_LANGUAGE: false
+          VALIDATE_KUBERNETES_KUBEVAL: false
           YAML_CONFIG_FILE: yaml/.yaml-lint.yml
           TERRAFORM_TFLINT_CONFIG_FILE: terraform/.tflint.hcl
           SQLFLUFF_CONFIG_FILE: sqlfluff/.sqlfluff-lint

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -39,6 +39,30 @@ on:
           "Will parse the entire repository and find all files to validate
           across all types. NOTE: When set to false, only new or edited files
           will be parsed for validation."
+      VALIDATE_KUBERNETES_KUBEVAL:
+        required: false
+        type: boolean
+        default: false
+        description: >
+          "Enable kubeval validation for Kubernetes manifests."
+      VALIDATE_GITHUB_ACTIONS:
+        required: false
+        type: boolean
+        default: false
+        description: >
+          "Enable GitHub Actions validation."
+      VALIDATE_CHECKOV:
+        required: false
+        type: boolean
+        default: false
+        description: >
+          "Enable Checkov validation."
+      VALIDATE_GITLEAKS:
+        required: false
+        type: boolean
+        default: false
+        description: >
+          "Enable Gitleaks validation."
 
 jobs:
   build:
@@ -60,8 +84,34 @@ jobs:
       - name: Configure git for private modules
         run: git config --global url."https://${{ github.token }}:x-oauth-basic@github.com/".insteadOf "https://github.com/"
 
-      - name: Lint Code Base
-        uses: github/super-linter/slim@v7
+      - name: Lint Code Base (include mode)
+        if: ${{ inputs.VALIDATE_KUBERNETES_KUBEVAL || inputs.VALIDATE_GITHUB_ACTIONS || inputs.VALIDATE_CHECKOV || inputs.VALIDATE_GITLEAKS }}
+        uses: github/super-linter@v7
+        env:
+          ANSIBLE_CONFIG_FILE: ansible/.ansible-lint.yml
+          ANSIBLE_DIRECTORY: ${{ inputs.ANSIBLE_DIRECTORY }}
+          CHECKOV_FILE_NAME: checkov/.checkov.yaml
+          DEFAULT_BRANCH: main
+          FILTER_REGEX_EXCLUDE: "${{ inputs.FILTER_REGEX_EXCLUDE }}"
+          GITHUB_TOKEN: ${{ github.token }}
+          JAVA_FILE_NAME: java/checkstyle/checkstyle.xml
+          KUBERNETES_KUBEVAL_OPTIONS: --ignore-missing-schemas
+          LINTER_RULES_PATH: "${{ inputs.CODEQUALITY_PATH }}/"
+          MARKDOWN_CONFIG_FILE: markdown/.markdown-lint.yml
+          VALIDATE_ALL_CODEBASE: "${{ inputs.VALIDATE_ALL_CODEBASE }}"
+          VALIDATE_MARKDOWN: "true"
+          VALIDATE_YAML: "true"
+          VALIDATE_KUBERNETES_KUBEVAL: ${{ inputs.VALIDATE_KUBERNETES_KUBEVAL && 'true' || '' }}
+          VALIDATE_GITHUB_ACTIONS: ${{ inputs.VALIDATE_GITHUB_ACTIONS && 'true' || '' }}
+          VALIDATE_CHECKOV: ${{ inputs.VALIDATE_CHECKOV && 'true' || '' }}
+          VALIDATE_GITLEAKS: ${{ inputs.VALIDATE_GITLEAKS && 'true' || '' }}
+          YAML_CONFIG_FILE: yaml/.yaml-lint.yml
+          TERRAFORM_TFLINT_CONFIG_FILE: terraform/.tflint.hcl
+          SQLFLUFF_CONFIG_FILE: sqlfluff/.sqlfluff-lint
+
+      - name: Lint Code Base (exclude mode)
+        if: ${{ !(inputs.VALIDATE_KUBERNETES_KUBEVAL || inputs.VALIDATE_GITHUB_ACTIONS || inputs.VALIDATE_CHECKOV || inputs.VALIDATE_GITLEAKS) }}
+        uses: github/super-linter@v7
         env:
           ANSIBLE_CONFIG_FILE: ansible/.ansible-lint.yml
           ANSIBLE_DIRECTORY: ${{ inputs.ANSIBLE_DIRECTORY }}
@@ -76,7 +126,6 @@ jobs:
           VALIDATE_ALL_CODEBASE: "${{ inputs.VALIDATE_ALL_CODEBASE }}"
           VALIDATE_JSCPD: false
           VALIDATE_NATURAL_LANGUAGE: false
-          VALIDATE_KUBERNETES_KUBEVAL: false
           YAML_CONFIG_FILE: yaml/.yaml-lint.yml
           TERRAFORM_TFLINT_CONFIG_FILE: terraform/.tflint.hcl
           SQLFLUFF_CONFIG_FILE: sqlfluff/.sqlfluff-lint

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -63,6 +63,18 @@ on:
         default: false
         description: >
           "Enable Gitleaks validation."
+      VALIDATE_MARKDOWN:
+        required: false
+        type: boolean
+        default: true
+        description: >
+          "Enable Markdown validation in include mode."
+      VALIDATE_YAML:
+        required: false
+        type: boolean
+        default: true
+        description: >
+          "Enable YAML validation in include mode."
       VALIDATE_MARKDOWN_PRETTIER:
         required: false
         type: boolean
@@ -111,8 +123,8 @@ jobs:
           LINTER_RULES_PATH: "${{ inputs.CODEQUALITY_PATH }}/"
           MARKDOWN_CONFIG_FILE: markdown/.markdown-lint.yml
           VALIDATE_ALL_CODEBASE: "${{ inputs.VALIDATE_ALL_CODEBASE }}"
-          VALIDATE_MARKDOWN: "true"
-          VALIDATE_YAML: "true"
+          VALIDATE_MARKDOWN: ${{ inputs.VALIDATE_MARKDOWN && 'true' || '' }}
+          VALIDATE_YAML: ${{ inputs.VALIDATE_YAML && 'true' || '' }}
           VALIDATE_KUBERNETES_KUBEVAL: ${{ inputs.VALIDATE_KUBERNETES_KUBEVAL && 'true' || '' }}
           VALIDATE_GITHUB_ACTIONS: ${{ inputs.VALIDATE_GITHUB_ACTIONS && 'true' || '' }}
           VALIDATE_CHECKOV: ${{ inputs.VALIDATE_CHECKOV && 'true' || '' }}

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -111,7 +111,7 @@ jobs:
 
       - name: Lint Code Base (exclude mode)
         if: ${{ !(inputs.VALIDATE_KUBERNETES_KUBEVAL || inputs.VALIDATE_GITHUB_ACTIONS || inputs.VALIDATE_CHECKOV || inputs.VALIDATE_GITLEAKS) }}
-        uses: github/super-linter@v7
+        uses: github/super-linter/slim@v7
         env:
           ANSIBLE_CONFIG_FILE: ansible/.ansible-lint.yml
           ANSIBLE_DIRECTORY: ${{ inputs.ANSIBLE_DIRECTORY }}

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -66,13 +66,13 @@ on:
       VALIDATE_MARKDOWN:
         required: false
         type: boolean
-        default: true
+        default: false
         description: >
           "Enable Markdown validation in include mode."
       VALIDATE_YAML:
         required: false
         type: boolean
-        default: true
+        default: false
         description: >
           "Enable YAML validation in include mode."
       VALIDATE_MARKDOWN_PRETTIER:
@@ -109,7 +109,7 @@ jobs:
         run: git config --global url."https://${{ github.token }}:x-oauth-basic@github.com/".insteadOf "https://github.com/"
 
       - name: Lint Code Base (include mode)
-        if: ${{ inputs.VALIDATE_KUBERNETES_KUBEVAL || inputs.VALIDATE_GITHUB_ACTIONS || inputs.VALIDATE_CHECKOV || inputs.VALIDATE_GITLEAKS || inputs.VALIDATE_MARKDOWN_PRETTIER || inputs.VALIDATE_YAML_PRETTIER }}
+        if: ${{ inputs.VALIDATE_KUBERNETES_KUBEVAL || inputs.VALIDATE_GITHUB_ACTIONS || inputs.VALIDATE_CHECKOV || inputs.VALIDATE_GITLEAKS || inputs.VALIDATE_MARKDOWN || inputs.VALIDATE_YAML || inputs.VALIDATE_MARKDOWN_PRETTIER || inputs.VALIDATE_YAML_PRETTIER }}
         uses: github/super-linter/slim@v7
         env:
           ANSIBLE_CONFIG_FILE: ansible/.ansible-lint.yml
@@ -136,7 +136,7 @@ jobs:
           SQLFLUFF_CONFIG_FILE: sqlfluff/.sqlfluff-lint
 
       - name: Lint Code Base (exclude mode)
-        if: ${{ !(inputs.VALIDATE_KUBERNETES_KUBEVAL || inputs.VALIDATE_GITHUB_ACTIONS || inputs.VALIDATE_CHECKOV || inputs.VALIDATE_GITLEAKS || inputs.VALIDATE_MARKDOWN_PRETTIER || inputs.VALIDATE_YAML_PRETTIER) }}
+        if: ${{ !(inputs.VALIDATE_KUBERNETES_KUBEVAL || inputs.VALIDATE_GITHUB_ACTIONS || inputs.VALIDATE_CHECKOV || inputs.VALIDATE_GITLEAKS || inputs.VALIDATE_MARKDOWN || inputs.VALIDATE_YAML || inputs.VALIDATE_MARKDOWN_PRETTIER || inputs.VALIDATE_YAML_PRETTIER) }}
         uses: github/super-linter/slim@v7
         env:
           ANSIBLE_CONFIG_FILE: ansible/.ansible-lint.yml

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -63,6 +63,18 @@ on:
         default: false
         description: >
           "Enable Gitleaks validation."
+      VALIDATE_MARKDOWN_PRETTIER:
+        required: false
+        type: boolean
+        default: false
+        description: >
+          "Enable Markdown Prettier validation."
+      VALIDATE_YAML_PRETTIER:
+        required: false
+        type: boolean
+        default: false
+        description: >
+          "Enable YAML Prettier validation."
 
 jobs:
   build:
@@ -85,7 +97,7 @@ jobs:
         run: git config --global url."https://${{ github.token }}:x-oauth-basic@github.com/".insteadOf "https://github.com/"
 
       - name: Lint Code Base (include mode)
-        if: ${{ inputs.VALIDATE_KUBERNETES_KUBEVAL || inputs.VALIDATE_GITHUB_ACTIONS || inputs.VALIDATE_CHECKOV || inputs.VALIDATE_GITLEAKS }}
+        if: ${{ inputs.VALIDATE_KUBERNETES_KUBEVAL || inputs.VALIDATE_GITHUB_ACTIONS || inputs.VALIDATE_CHECKOV || inputs.VALIDATE_GITLEAKS || inputs.VALIDATE_MARKDOWN_PRETTIER || inputs.VALIDATE_YAML_PRETTIER }}
         uses: github/super-linter@v7
         env:
           ANSIBLE_CONFIG_FILE: ansible/.ansible-lint.yml
@@ -105,12 +117,14 @@ jobs:
           VALIDATE_GITHUB_ACTIONS: ${{ inputs.VALIDATE_GITHUB_ACTIONS && 'true' || '' }}
           VALIDATE_CHECKOV: ${{ inputs.VALIDATE_CHECKOV && 'true' || '' }}
           VALIDATE_GITLEAKS: ${{ inputs.VALIDATE_GITLEAKS && 'true' || '' }}
+          VALIDATE_MARKDOWN_PRETTIER: ${{ inputs.VALIDATE_MARKDOWN_PRETTIER && 'true' || '' }}
+          VALIDATE_YAML_PRETTIER: ${{ inputs.VALIDATE_YAML_PRETTIER && 'true' || '' }}
           YAML_CONFIG_FILE: yaml/.yaml-lint.yml
           TERRAFORM_TFLINT_CONFIG_FILE: terraform/.tflint.hcl
           SQLFLUFF_CONFIG_FILE: sqlfluff/.sqlfluff-lint
 
       - name: Lint Code Base (exclude mode)
-        if: ${{ !(inputs.VALIDATE_KUBERNETES_KUBEVAL || inputs.VALIDATE_GITHUB_ACTIONS || inputs.VALIDATE_CHECKOV || inputs.VALIDATE_GITLEAKS) }}
+        if: ${{ !(inputs.VALIDATE_KUBERNETES_KUBEVAL || inputs.VALIDATE_GITHUB_ACTIONS || inputs.VALIDATE_CHECKOV || inputs.VALIDATE_GITLEAKS || inputs.VALIDATE_MARKDOWN_PRETTIER || inputs.VALIDATE_YAML_PRETTIER) }}
         uses: github/super-linter/slim@v7
         env:
           ANSIBLE_CONFIG_FILE: ansible/.ansible-lint.yml

--- a/README.md
+++ b/README.md
@@ -9,8 +9,44 @@ Use this workflow if your repository consists of multiple file formats (e.g. Jav
 Add a new workflow file like [this one](.github/workflows/lint.yml) or add the following lines to a existing workflow:
 
 ```yaml
-  call-lint-workflow:
-    uses: "riege/code-quality/.github/workflows/super-linter.yml@v1.0.0"
+call-lint-workflow:
+uses: "riege/code-quality/.github/workflows/super-linter.yml@v1.0.0"
+```
+
+Optional input to enable kubeval for Kubernetes manifests:
+
+```yaml
+call-lint-workflow:
+uses: "riege/code-quality/.github/workflows/super-linter.yml@v1.0.0"
+with:
+  VALIDATE_KUBERNETES_KUBEVAL: true
+```
+
+Optional input to enable GitHub Actions validation:
+
+```yaml
+call-lint-workflow:
+uses: "riege/code-quality/.github/workflows/super-linter.yml@v1.0.0"
+with:
+  VALIDATE_GITHUB_ACTIONS: true
+```
+
+Optional input to enable Checkov validation:
+
+```yaml
+call-lint-workflow:
+uses: "riege/code-quality/.github/workflows/super-linter.yml@v1.0.0"
+with:
+  VALIDATE_CHECKOV: true
+```
+
+Optional input to enable Gitleaks validation:
+
+```yaml
+call-lint-workflow:
+uses: "riege/code-quality/.github/workflows/super-linter.yml@v1.0.0"
+with:
+  VALIDATE_GITLEAKS: true
 ```
 
 ## Terraform
@@ -21,12 +57,12 @@ Usage:
 
 ```yaml
 jobs:
-  lint:
-    uses: riege/code-quality/.github/workflows/terraform.yml@v1.0.0
-    with:
-      skip_init: false
-      skip_validate: false
-    secrets: inherit
+lint:
+  uses: riege/code-quality/.github/workflows/terraform.yml@v1.0.0
+  with:
+    skip_init: false
+    skip_validate: false
+  secrets: inherit
 ```
 
 - use `skip_init: true` if `terraform init` doesn't work properly during workflow run.

--- a/README.md
+++ b/README.md
@@ -57,12 +57,12 @@ Usage:
 
 ```yaml
 jobs:
-lint:
-  uses: riege/code-quality/.github/workflows/terraform.yml@v1.0.0
-  with:
-    skip_init: false
-    skip_validate: false
-  secrets: inherit
+  lint:
+    uses: riege/code-quality/.github/workflows/terraform.yml@v1.0.0
+    with:
+      skip_init: false
+      skip_validate: false
+    secrets: inherit
 ```
 
 - use `skip_init: true` if `terraform init` doesn't work properly during workflow run.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,24 @@ with:
   VALIDATE_GITLEAKS: true
 ```
 
+Optional input to enable Markdown Prettier validation:
+
+```yaml
+call-lint-workflow:
+uses: "riege/code-quality/.github/workflows/super-linter.yml@v1.0.0"
+with:
+  VALIDATE_MARKDOWN_PRETTIER: true
+```
+
+Optional input to enable YAML Prettier validation:
+
+```yaml
+call-lint-workflow:
+uses: "riege/code-quality/.github/workflows/super-linter.yml@v1.0.0"
+with:
+  VALIDATE_YAML_PRETTIER: true
+```
+
 ## Terraform
 
 The workflow `terraform.yml` is intended for repositories consisting of Terraform files only. It's small and fast and properly checks Terraform configurations.

--- a/README.md
+++ b/README.md
@@ -67,22 +67,22 @@ with:
   VALIDATE_YAML_PRETTIER: true
 ```
 
-Optional input to disable Markdown validation in include mode:
+Optional input to enable Markdown validation in include mode:
 
 ```yaml
 call-lint-workflow:
 uses: "riege/code-quality/.github/workflows/super-linter.yml@v1.0.0"
 with:
-  VALIDATE_MARKDOWN: false
+  VALIDATE_MARKDOWN: true
 ```
 
-Optional input to disable YAML validation in include mode:
+Optional input to enable YAML validation in include mode:
 
 ```yaml
 call-lint-workflow:
 uses: "riege/code-quality/.github/workflows/super-linter.yml@v1.0.0"
 with:
-  VALIDATE_YAML: false
+  VALIDATE_YAML: true
 ```
 
 ## Terraform

--- a/README.md
+++ b/README.md
@@ -67,6 +67,24 @@ with:
   VALIDATE_YAML_PRETTIER: true
 ```
 
+Optional input to disable Markdown validation in include mode:
+
+```yaml
+call-lint-workflow:
+uses: "riege/code-quality/.github/workflows/super-linter.yml@v1.0.0"
+with:
+  VALIDATE_MARKDOWN: false
+```
+
+Optional input to disable YAML validation in include mode:
+
+```yaml
+call-lint-workflow:
+uses: "riege/code-quality/.github/workflows/super-linter.yml@v1.0.0"
+with:
+  VALIDATE_YAML: false
+```
+
 ## Terraform
 
 The workflow `terraform.yml` is intended for repositories consisting of Terraform files only. It's small and fast and properly checks Terraform configurations.


### PR DESCRIPTION
This PR adds reusable workflow inputs for VALIDATE_KUBERNETES_KUBEVAL, 
VALIDATE_GITHUB_ACTIONS, VALIDATE_CHECKOV, and VALIDATE_GITLEAKS. It introduces
include/exclude mode handling to avoid super-linter include/exclude conflicts
and updates the README with usage examples.