### PR TITLE
Revert "fix: add ignore-regex for cloudinit cloud-config in comments rule"

### DIFF
--- a/yaml/.yaml-lint.yml
+++ b/yaml/.yaml-lint.yml
@@ -11,8 +11,6 @@ rules:
   comments:
     require-starting-space: true
     ignore-shebangs: true
-    ignore-regex:
-      - ^#cloud-config
     min-spaces-from-content: 1
     level: error
   document-start: disable


### PR DESCRIPTION
Reverts riege/code-quality#88
This is not a working feature.