### PR TITLE
Add GITLEAKS_CONFIG_FILE input for Gitleaks validation in workflows

### DIFF
--- a/.github/workflows/super-linter-non-slim.yml
+++ b/.github/workflows/super-linter-non-slim.yml
@@ -75,6 +75,12 @@ on:
         default: false
         description: >
           "Enable Gitleaks validation."
+      GITLEAKS_CONFIG_FILE:
+        required: false
+        type: string
+        default: ".gitleaks.toml"
+        description: >
+          "Filename for Gitleaks configuration."
       VALIDATE_BASH:
         required: false
         type: boolean
@@ -142,6 +148,7 @@ jobs:
           DEFAULT_BRANCH: main
           FILTER_REGEX_EXCLUDE: "${{ inputs.FILTER_REGEX_EXCLUDE }}"
           GITHUB_TOKEN: ${{ github.token }}
+          GITLEAKS_CONFIG_FILE: "${{ inputs.GITLEAKS_CONFIG_FILE }}"
           JAVA_FILE_NAME: java/checkstyle/checkstyle.xml
           KUBERNETES_KUBEVAL_FILE_NAME: "${{ inputs.KUBERNETES_KUBEVAL_FILE_NAME }}"
           KUBERNETES_KUBEVAL_OPTIONS: --ignore-missing-schemas
@@ -174,6 +181,7 @@ jobs:
           DEFAULT_BRANCH: main
           FILTER_REGEX_EXCLUDE: "${{ inputs.FILTER_REGEX_EXCLUDE }}"
           GITHUB_TOKEN: ${{ github.token }}
+          GITLEAKS_CONFIG_FILE: "${{ inputs.GITLEAKS_CONFIG_FILE }}"
           JAVA_FILE_NAME: java/checkstyle/checkstyle.xml
           # KUBERNETES_KUBEVAL_FILE_NAME: "${{ inputs.KUBERNETES_KUBEVAL_FILE_NAME }}"
           KUBERNETES_KUBEVAL_OPTIONS: --ignore-missing-schemas

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -75,6 +75,12 @@ on:
         default: false
         description: >
           "Enable Gitleaks validation."
+      GITLEAKS_CONFIG_FILE:
+        required: false
+        type: string
+        default: ".gitleaks.toml"
+        description: >
+          "Filename for Gitleaks configuration."
       VALIDATE_BASH:
         required: false
         type: boolean
@@ -142,6 +148,7 @@ jobs:
           DEFAULT_BRANCH: main
           FILTER_REGEX_EXCLUDE: "${{ inputs.FILTER_REGEX_EXCLUDE }}"
           GITHUB_TOKEN: ${{ github.token }}
+          GITLEAKS_CONFIG_FILE: "${{ inputs.GITLEAKS_CONFIG_FILE }}"
           JAVA_FILE_NAME: java/checkstyle/checkstyle.xml
           KUBERNETES_KUBEVAL_FILE_NAME: "${{ inputs.KUBERNETES_KUBEVAL_FILE_NAME }}"
           KUBERNETES_KUBEVAL_OPTIONS: --ignore-missing-schemas
@@ -174,6 +181,7 @@ jobs:
           DEFAULT_BRANCH: main
           FILTER_REGEX_EXCLUDE: "${{ inputs.FILTER_REGEX_EXCLUDE }}"
           GITHUB_TOKEN: ${{ github.token }}
+          GITLEAKS_CONFIG_FILE: "${{ inputs.GITLEAKS_CONFIG_FILE }}"
           JAVA_FILE_NAME: java/checkstyle/checkstyle.xml
           # KUBERNETES_KUBEVAL_FILE_NAME: "${{ inputs.KUBERNETES_KUBEVAL_FILE_NAME }}"
           KUBERNETES_KUBEVAL_OPTIONS: --ignore-missing-schemas


### PR DESCRIPTION
Introduce a new input for specifying the Gitleaks configuration file in the super-linter workflows, enhancing flexibility for Gitleaks validation.