### PR TITLE
Add gitleaks configuration for Grafana dashboards

### DIFF
--- a/gitleaks/.gitleaks-grafana.toml
+++ b/gitleaks/.gitleaks-grafana.toml
@@ -1,0 +1,13 @@
+title = "gitleaks config for grafana-dashboards"
+
+[extend]
+useDefault = true
+
+[[allowlists]]
+description = "Allow Grafana panel target key identifiers in dashboard JSON files"
+paths = [
+  '''^dashboards(?:-fra)?/.+\.json$''',
+]
+regexes = [
+  '''"key"\s*:\s*"Q-[0-9a-fA-F-]+-[0-9]+"''',
+]


### PR DESCRIPTION
Introduce a gitleaks configuration file to allow specific identifiers in Grafana dashboard JSON files, enhancing security checks for dashboard configurations.